### PR TITLE
Dv fixes

### DIFF
--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -303,7 +303,9 @@ EOF
 
 
   ### GRAB CHAPTERS
-  mkvextract chapters -s "${output}.asm" > chapters.list
+  if [ -s "${output}.asm" ]; then
+    mkvextract chapters -s "${output}.asm" > chapters.list
+  fi
   
   ### MUX MP4
   mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=$dv_target")

--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -130,6 +130,10 @@ for f in *.mkv;do
       else
         dv_target=8
       fi
+      ### DETIRMINE DV COMPATIBILITY FOR PROFILE 8
+      if [ "$dv_profile" -eq 8 ]; then
+        dv_compatibility=$(mediainfo "$input" | grep "HDR format.*dvhe\." | sed -rn 's/(^|(.* ))([^ ]*) compatible(( .*)|$)/.\3/; T; p; q' | tr '[:upper:]' '[:lower:]')
+      fi
     elif [ ! -z "$hdr10plus" ]; then
       echo "Converting HDR10+ to DV8: \"$input\""
       dv_target=8
@@ -308,7 +312,7 @@ EOF
   fi
   
   ### MUX MP4
-  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=$dv_target")
+  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=${dv_target}${dv_compatibility}")
   tcount=2
   while read i;do
     stream=`echo "$i" | cut -f1 -d\|`


### PR DESCRIPTION
Hi,
Here are two small corrections to the script.
- The first adds a precheck to the chapter.list generation. Without this that line generates a dummy file with errorous content and the MP4box fails later.
- The second adds the DV compatibility to after the DV target in the MP4box. If I tried to convert a file with profile 8 it required the compatibility and otherwise it dropped this error: _DV profile 8 must indicate a compatibility mode `hdr10` or `bt709`_