### PR TITLE
Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,30 @@ Options:
 
 dvmkv2mp4 -l und,pol,eng -r -a # will process mkvs found in folder keep only undefined, Polish and English tracks, will remove source file once done and will create audio-subs-meta file for future needs
 ```
+
+# Docker (experimental)
+The following section assumes that you installed Docker on your machine. For further instrcution to install Docker follow the official site: https://docs.docker.com/get-docker/
+
+## Build Docker image
+Currently the image works only on x64 Linux. Also note that the final image size will be close to 6 GB which is normal as it includes the Tesseract OCR models.
+
+To build your Docker image run the following command:
+```
+docker build -t dvmkv2mp4  https://github.com/gacopl/dvmkv2mp4.git#main -f docker/Dockerfile
+```
+## Use the Docker image
+The usage is similar to the normal variant but here you need to attach your folder where you would like to convert your files. You can also add the flags at the end of the command.
+
+Example:
+```
+# docker run -it --rm -v <YOUR_FOLDER_PATH>:/convert dvmkv2mp4
+
+docker run -it --rm -v /media/mkvvideos:/convert dvmkv2mp4 -l und,pol,eng -r -a
+```
+This example does the same which is mentioned in setion Usage.
+
 # Roadmap
-- docker version
+- docker image for other systems
 - helper scripts for Radarr, Sonarr to automatically run on import
 - convert directly from Bluray bdmv mpls file (have it working in alpha state already)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,9 @@ RUN \
     ffmpeg \
     mediainfo \
     mkvtoolnix && \
-  printf "\n---Cleanup apt cache---\n\n" && \
+  printf "\n---Uninstall unneccassary tools and cleanup apt cache---\n\n" && \
+  apt-get purge -y software-properties-common && \
+  apt-get autoremove -y && \
   rm -rf \
     /var/lib/apt/lists/* \
     /var/tmp/*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/546d50b2
 ARG pgs2srtlink="https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip"
 ARG tesseractlink="https://github.com/tesseract-ocr/tessdata.git"
 
-COPY /dvmkv2mp4 /usr/local/bin
+COPY ../dvmkv2mp4 /usr/local/bin
 
 RUN chmod a+x /usr/local/bin/dvmkv2mp4
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,106 @@
+FROM ubuntu:20.04
+
+ARG mediainforepo="https://mediaarea.net/repo/deb/repo-mediaarea_1.0-19_all.deb"
+ARG dovitoollink="https://github.com/quietvoid/dovi_tool/releases/download/1.4.6/dovi_tool-1.4.6-x86_64-unknown-linux-musl.tar.gz"
+ARG hdr10plustoollink="https://github.com/quietvoid/hdr10plus_tool/releases/download/1.2.2/hdr10plus_tool-1.2.2-x86_64-unknown-linux-musl.tar.gz"
+ARG mp4boxlink="https://github.com/gpac/gpac.git"
+ARG mp4boxtag="v1.0.1"
+ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/546d50b2-d85c-433f-b13b-b896f1bc1916/17d7bbb674bf67c3d490489b20a437b7/dotnet-runtime-5.0.15-linux-x64.tar.gz"
+ARG pgs2srtlink="https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip"
+ARG tesseractlink="https://github.com/tesseract-ocr/tessdata.git"
+
+COPY /dvmkv2mp4 /usr/local/bin
+
+RUN chmod a+x /usr/local/bin/dvmkv2mp4
+
+# Install MEDIAINFO MKVTOOLNIX FFMPEG WGET
+RUN \
+  printf "\n---Install mediainfo mkvtoolnix ffmpeg and wget---\n\n" && \
+  apt-get update && \
+  apt-get install -y software-properties-common wget && \
+  add-apt-repository ppa:savoury1/ffmpeg4 && \
+  wget -O /usr/share/keyrings/gpg-pub-moritzbunkus.gpg https://mkvtoolnix.download/gpg-pub-moritzbunkus.gpg && \
+  echo "deb [signed-by=/usr/share/keyrings/gpg-pub-moritzbunkus.gpg] https://mkvtoolnix.download/ubuntu/ focal main" | tee -a /etc/apt/sources.list && \
+  wget ${mediainforepo} -O temp.deb && \
+  dpkg -i temp.deb && \
+  rm temp.deb && \
+  apt-get update && \
+  apt-get install -y \
+    ffmpeg \
+    mediainfo \
+    mkvtoolnix && \
+  printf "\n---Cleanup apt cache---\n\n" && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+# DOVI_TOOL
+RUN \
+  printf "\n---Download dovi_tool---\n\n" && \
+  wget -O - ${dovitoollink} | \
+  tar -zx -C /usr/local/bin/
+
+# HDR10PLUS_TOOL
+RUN \
+  printf "\n---Download hdr10plus_tool---\n\n" && \
+  wget -O - ${hdr10plustoollink} | \
+  tar -zx -C /usr/local/bin/
+
+# MP4BOX
+RUN \
+  printf "\n---Download build utils---\n\n" && \
+  apt-get update && \
+  apt-get install -y build-essential pkg-config git && \
+  apt-get install -y zlib1g-dev && \
+  printf "\n---Build mp4box---\n\n" && \
+  mkdir mp4box && \
+  cd mp4box && \
+  git clone --branch ${mp4boxtag} ${mp4boxlink} gpac_public && \
+  cd gpac_public && \
+  ./configure --static-bin && \
+  make -j $(nproc) && \
+  make install && \
+  MP4Box -version && \
+  cd ../.. && \
+  printf "\n---Uninstall build utils and cleanup apt cache---\n\n" && \
+  rm -Rf mp4box && \
+  apt-get purge -y build-essential pkg-config git && \
+  apt-get purge -y zlib1g-dev && \
+  apt-get autoremove -y && \
+  rm -rf \ 
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+# PGS2SRT
+RUN \
+  printf "\n---Download dotnet runtime---\n\n" && \
+  mkdir /opt/dotnet && \
+  wget -O - ${dotnetlink} | \
+  tar -zx -C /opt/dotnet/ && \
+  printf "\n---Install tesseract and git---\n\n" && \
+  apt-get update && \
+  apt-get install -y libtesseract4 unzip git && \
+  printf "\n---Download pgs2srt---\n\n" && \
+  mkdir /opt/PgsToSrt && \
+  wget ${pgs2srtlink} -O temp.zip && \
+  unzip -d /opt/PgsToSrt/ temp.zip && \
+  rm temp.zip && \
+  printf "\n---Download tesseract models---\n\n" && \
+  cd /opt/PgsToSrt/net5 && \
+  git clone ${tesseractlink} && \
+  printf "\n---Uninstall unzip and git and cleanup apt cache---\n\n" && \
+  apt-get purge -y unzip git && \
+  apt-get autoremove -y && \
+  rm -rf \ 
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+RUN \
+  printf "\n---Create \"convert\" directory for volumne attachment---\n\n" && \
+  mkdir /convert
+
+VOLUME ["/convert"]
+
+WORKDIR /convert
+
+ENTRYPOINT ["dvmkv2mp4"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/546d50b2
 ARG pgs2srtlink="https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip"
 ARG tesseractlink="https://github.com/tesseract-ocr/tessdata.git"
 
-COPY ../dvmkv2mp4 /usr/local/bin
+COPY /dvmkv2mp4 /usr/local/bin
 
 RUN chmod a+x /usr/local/bin/dvmkv2mp4
 


### PR DESCRIPTION
I created a Dockerfile for the project based on the Installation steps.
There are small changes to adapt to the docker best practises.

You can build the container and test without the PR merge with this command:
docker build -t dvmkv2mp4  https://github.com/szasza576/dvmkv2mp4.git#docker -f docker/Dockerfile

The usage is the same as written in the Readme.

Note that the final image size is ~5.8GB where 5GB comes from the Tesseract OCR models. Otherwise I tried to keep the size minimal however there might be room for improvements.

I'm working on a Docker image for ARM64 (Raspberry PI4). It progress well but I'm fighting with Mediainfo where the ARM64 isn't in the repo yet. Once that is done then I make another PR.