### PR TITLE
dvmkv2mp4 on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ wget https://raw.githubusercontent.com/gacopl/dvmkv2mp4/main/dvmkv2mp4
 chmod a+x dvmkv2mp4
 mv dvmkv2mp4 /usr/local/bin/
 ```
+
+To use dvmkv2mp4 in OS X:
+- install all required packages as for Ubuntu 20.04
+- install ionice-MacOS
+
 # Usage
 ```
 In directory containing Dolby Vision mkv simply run `dvmkv2mp4`it will process any mkvs found in that dir

--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -9,8 +9,13 @@ ASM="no"
 REMOVESOURCE="no"
 ## Whether to allow debug by keeping conversion data
 DEBUG="no"
-## Set ionice level to idle to not hammer disks during conversion
-ionc="ionice -c 3"
+## Check OSTYPE and set ionice level to idle to not hammer disks during conversion
+if [[ $OSTYPE == 'darwin'* ]]
+then
+  ionc="ionice --low"
+else
+  ionc="ionice -c 3"
+fi
 
 HEADER="dvmkv2mp4 $VERSION - easily convert Dolby Vision or HDR10+ mkvs to Dolby Vision MP4 
 Created by github.com/gacopl, Released under GPLv3
@@ -81,8 +86,6 @@ function processsubs {
       done <<< "$(cat sub.exports | grep hdmv_pgs)"
     fi
 }
-
-ionc="ionice -c 3"
 
 start=`date +%s`
 echo "$HEADER"


### PR DESCRIPTION
Hi! Not sure if this PR is really needed, but I've managed to launch dvmkv2mp4 on MacOS by changing two rows in exec file and using ionice analog for mac. This small comment might help somebody who wants to use dvmkv2mp4 on apple system.