### PR TITLE
PGS2SRT - use dotnet6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ make
 sudo make install
 MP4Box -version # MAKE SURE IT SAYS 1.0.1
 # PGS2SRT
-wget https://download.visualstudio.microsoft.com/download/pr/546d50b2-d85c-433f-b13b-b896f1bc1916/17d7bbb674bf67c3d490489b20a437b7/dotnet-runtime-5.0.15-linux-x64.tar.gz
-tar -zxf dotnet-runtime-5.0.15-linux-x64.tar.gz
+wget https://download.visualstudio.microsoft.com/download/pr/48fbc600-8228-424e-aaed-52b7e601c277/c493b8ac4629341f1e5acc4ff515fead/dotnet-runtime-6.0.10-linux-x64.tar.gz
+tar -zxf dotnet-runtime-6.0.10-linux-x64.tar.gz
 sudo mkdir /opt/dotnet
 sudo mv * /opt/dotnet
 cd /opt
@@ -63,7 +63,7 @@ sudo mkdir /opt/PgsToSrt
 cd /opt/PgsToSrt
 sudo wget https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip
 sudo unzip PgsToSrt-1.4.2.zip
-cd net5
+cd net6
 sudo git clone https://github.com/tesseract-ocr/tessdata.git
 ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ ARG dovitoollink="https://github.com/quietvoid/dovi_tool/releases/download/1.4.6
 ARG hdr10plustoollink="https://github.com/quietvoid/hdr10plus_tool/releases/download/1.2.2/hdr10plus_tool-1.2.2-x86_64-unknown-linux-musl.tar.gz"
 ARG mp4boxlink="https://github.com/gpac/gpac.git"
 ARG mp4boxtag="v1.0.1"
-ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/546d50b2-d85c-433f-b13b-b896f1bc1916/17d7bbb674bf67c3d490489b20a437b7/dotnet-runtime-5.0.15-linux-x64.tar.gz"
+ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/48fbc600-8228-424e-aaed-52b7e601c277/c493b8ac4629341f1e5acc4ff515fead/dotnet-runtime-6.0.10-linux-x64.tar.gz"
 ARG pgs2srtlink="https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip"
 ARG tesseractlink="https://github.com/tesseract-ocr/tessdata.git"
 
@@ -74,7 +74,7 @@ RUN \
   unzip -d /opt/PgsToSrt/ temp.zip && \
   rm temp.zip && \
   printf "\n---Download tesseract models---\n\n" && \
-  cd /opt/PgsToSrt/net5 && \
+  cd /opt/PgsToSrt/net6 && \
   git clone ${tesseractlink} && \
   printf "\n---Uninstall unzip and git and cleanup apt cache---\n\n" && \
   apt-get purge -y software-properties-common build-essential pkg-config git zlib1g-dev unzip git && \

--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -90,7 +90,7 @@ function processsubs {
         delay=`echo "$i" | cut -f5 -d\|`
         lang=`echo "$i" | cut -f6 -d\|`
         title=`echo "$i" | cut -f7 -d\|`
-        /opt/dotnet/dotnet /opt/PgsToSrt/net5/PgsToSrt.dll --input "$stream" --output "${stream%.sup}.srt" --tesseractlanguage=$lang
+        /opt/dotnet/dotnet /opt/PgsToSrt/net6/PgsToSrt.dll --input "$stream" --output "${stream%.sup}.srt" --tesseractlanguage=$lang
         echo "${stream%.sup}.srt|$id|srt|$orig_codec|$delay|$lang|$title" >> sub.exports
         #docker run --rm -v "`pwd`":/data -e INPUT="/data/$stream" -e OUTPUT="/data/${stream%.sup}.srt" -e LANGUAGE=$lang tentacule/pgstosrt
       done <<< "$(cat sub.exports | grep hdmv_pgs)"


### PR DESCRIPTION
dotnet5 version of PGS2SRT had write error on CIFS mounted volumes. dotnet6 works correctly