### PR TITLE
Update base image to ubuntu 22.04 and dependencies

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-ARG mediainforepo="https://mediaarea.net/repo/deb/repo-mediaarea_1.0-19_all.deb"
-ARG dovitoollink="https://github.com/quietvoid/dovi_tool/releases/download/1.4.6/dovi_tool-1.4.6-x86_64-unknown-linux-musl.tar.gz"
-ARG hdr10plustoollink="https://github.com/quietvoid/hdr10plus_tool/releases/download/1.2.2/hdr10plus_tool-1.2.2-x86_64-unknown-linux-musl.tar.gz"
+ARG mediainforepo="https://mediaarea.net/repo/deb/repo-mediaarea_1.0-21_all.deb"
+ARG dovitoollink="https://github.com/quietvoid/dovi_tool/releases/download/2.0.3/dovi_tool-2.0.3-x86_64-unknown-linux-musl.tar.gz"
+ARG hdr10plustoollink="https://github.com/quietvoid/hdr10plus_tool/releases/download/1.6.0/hdr10plus_tool-1.6.0-x86_64-unknown-linux-musl.tar.gz"
 ARG mp4boxlink="https://github.com/gpac/gpac.git"
-ARG mp4boxtag="v1.0.1"
+ARG mp4boxtag="v2.2.1"
 ARG dotnetlink="https://download.visualstudio.microsoft.com/download/pr/48fbc600-8228-424e-aaed-52b7e601c277/c493b8ac4629341f1e5acc4ff515fead/dotnet-runtime-6.0.10-linux-x64.tar.gz"
 ARG pgs2srtlink="https://github.com/Tentacule/PgsToSrt/releases/download/v1.4.2/PgsToSrt-1.4.2.zip"
 ARG tesseractlink="https://github.com/tesseract-ocr/tessdata.git"
@@ -20,7 +20,7 @@ RUN \
   apt-get install -y software-properties-common wget && \
   add-apt-repository ppa:savoury1/ffmpeg4 && \
   wget -O /usr/share/keyrings/gpg-pub-moritzbunkus.gpg https://mkvtoolnix.download/gpg-pub-moritzbunkus.gpg && \
-  echo "deb [signed-by=/usr/share/keyrings/gpg-pub-moritzbunkus.gpg] https://mkvtoolnix.download/ubuntu/ focal main" | tee -a /etc/apt/sources.list && \
+  echo "deb [signed-by=/usr/share/keyrings/gpg-pub-moritzbunkus.gpg] https://mkvtoolnix.download/ubuntu/ jammy main" | tee -a /etc/apt/sources.list && \
   wget ${mediainforepo} -O temp.deb && \
   dpkg -i temp.deb && \
   rm temp.deb && \
@@ -42,8 +42,7 @@ RUN \
 RUN \
   printf "\n---Download hdr10plus_tool---\n\n" && \
   wget -O - ${hdr10plustoollink} | \
-  tar -zx -C /usr/local/bin/ && \
-  mv /usr/local/bin/dist/* /usr/local/bin/
+  tar -zx -C /usr/local/bin/
 
 # MP4BOX
 RUN \
@@ -65,9 +64,7 @@ RUN \
 # PGS2SRT
 RUN \
   printf "\n---Download dotnet runtime---\n\n" && \
-  mkdir /opt/dotnet && \
-  wget -O - ${dotnetlink} | \
-  tar -zx -C /opt/dotnet/ && \
+  apt-get update && apt-get install -y dotnet-runtime-6.0 && \
   printf "\n---Install tesseract and git---\n\n" && \
   apt-get install -y libtesseract4 unzip git && \
   printf "\n---Download pgs2srt---\n\n" && \
@@ -81,13 +78,13 @@ RUN \
   printf "\n---Uninstall unzip and git and cleanup apt cache---\n\n" && \
   apt-get purge -y software-properties-common build-essential pkg-config git zlib1g-dev unzip git && \
   apt-get autoremove -y && \
-  rm -rf \ 
+  rm -rf \
     /var/lib/apt/lists/* \
     /var/tmp/*
 
 RUN \
   printf "\n---Create \"convert\" directory for volume attachment---\n\n" && \
-  mkdir /convert
+  mkdir /convert /.gpac && chmod 777 /.gpac
 
 VOLUME ["/convert"]
 

--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -92,7 +92,7 @@ function processsubs {
         delay=`echo "$i" | cut -f5 -d\|`
         lang=`echo "$i" | cut -f6 -d\|`
         title=`echo "$i" | cut -f7 -d\|`
-        /opt/dotnet/dotnet /opt/PgsToSrt/net6/PgsToSrt.dll --input "$stream" --output "${stream%.sup}.srt" --tesseractlanguage=$lang
+        dotnet /opt/PgsToSrt/net6/PgsToSrt.dll --input "$stream" --output "${stream%.sup}.srt" --tesseractlanguage=$lang
         echo "${stream%.sup}.srt|$id|srt|$orig_codec|$delay|$lang|$title" >> sub.exports
         #docker run --rm -v "`pwd`":/data -e INPUT="/data/$stream" -e OUTPUT="/data/${stream%.sup}.srt" -e LANGUAGE=$lang tentacule/pgstosrt
       done <<< "$(cat sub.exports | grep hdmv_pgs)"
@@ -143,11 +143,11 @@ for f in *.mkv;do
       elif [ "$dv_profile" -eq 4 ]; then
         dv_target=4
       else
-        dv_target=8
+        dv_target=8.hdr10
       fi
     elif [ ! -z "$hdr10plus" ]; then
       echo "Converting HDR10+ to DV8: \"$input\""
-      dv_target=8
+      dv_target=8.hdr10
       ffstring=("$ffstarthdr10plus")
       MaxDML=`mediainfo "$input" | grep 'Mastering display luminance' | cut -f 4 -d:`
       MaxDML=${MaxDML% cd*}
@@ -315,7 +315,7 @@ EOF
       inputbase=${input%.mkv}
       dvmp4sub=`echo ${input%.mkv} | $sed 's/\ DV\|\ HDR10+//g'`
       for i in "$dvmp4sub"\ DV-MP4.*.{srt,sup}; do 
-          eval "cp \"$i\" \"`echo "$i" | $sed 's/\ DV-MP4//g' | $sed \"s/.*\.\(.*\)\.\(s..\)/\$inputbase\.\1\.\2/g\"`\"";
+          eval "cp \"$i\" \"`echo "$i" | $sed 's/\ DV-MP4//g' | $sed \"s/*\.\(.*\)\.\(s..\)/\$inputbase\.\1\.\2/g\"`\"";
       done
       rm BL.hevc *DV-MP4.asm *DV-MP4.*.srt *DV-MP4.sup ${input}.dvconverting
       continue
@@ -327,7 +327,7 @@ EOF
   mkvextract chapters -s "${input}" > chapters.list
   
   ### MUX MP4
-  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dv-profile=$dv_target")
+  mp4string=("$ionc MP4Box -add BL_RPU.hevc:dvp=$dv_target")
   tcount=2
   while read i;do
     stream=`echo "$i" | cut -f1 -d\|`


### PR DESCRIPTION
Hi,

This PR updates the base image and dependencies used with the docker flow. I was not able to complete the conversion with the actual version. 

This is the command i have run to test the conversion 

```bash
docker run -it -u $(id -u):$(id -g) --rm -v /<dvmkv2mp4_dir>/dvmkv2mp4:/usr/local/bin/dvmkv2mpa -v "<mkv_path>":/convert dvmkv2mp4 -s
```

I have just test on docker version. If you want, I can also test and update the readme for the native one. 