### PR TITLE
fix: preserve original video fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Converts any Dolby Vision (Profile 5, 7 Single Track, 7 Dual Track, 8) / HDR10+ 
 
 # Requirements
 - ffmpeg 6.0
+- ffprobe 6.x
 - **mp4box 2.2.1**
 - dovi_tool 2.1.0
 - hdr10plus_tool 1.6.0

--- a/dvmkv2mp4
+++ b/dvmkv2mp4
@@ -481,8 +481,11 @@ EOF
     echo
     dv_target=5
   fi
-  
-  mp4string=("$ionc MP4Box -add \"${TEMP_DIR}BL_RPU.hevc\":dvp=${dv_target}:hdr=none")
+
+  fps=$(ffprobe -v error -select_streams v -show_entries stream=avg_frame_rate -of csv=p=0 "$input" | awk -F '/' '{if ($2) {print $1/$2} else {print $1}}')
+  echo "Detected framerate: $fps"
+
+  mp4string=("$ionc MP4Box -add \"${TEMP_DIR}BL_RPU.hevc\":dvp=${dv_target}:fps=${fps}:hdr=none")
   tcount=2
   while read i;do
     stream=`echo "$i" | cut -f1 -d\|`


### PR DESCRIPTION
Preserves original video FPS to avoid audio and subtitle sync issue.

Some videos have 24 - 26 fps and encoding them with mp4box converts  23.976 fps which makes video a bit longer and causes audio and subtitle sync issues.